### PR TITLE
Add pre build environment

### DIFF
--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -1,0 +1,36 @@
+name: Create OCI 
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Docker Images
+        uses: philips-software/docker-ci-scripts@v5.0.0
+        with:
+          image-name: github-issue-forms-parser
+          tags: latest 0.1
+          push-branches: main
+          slsa-provenance: true
+          sign: true
+          sbom: true
+        env:
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_URL: ghcr.io/edumserrano
+          GITHUB_ORGANIZATION: edumserrano
+          KEYLESS: true

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
     description: 'The parsed issue form as a JSON string.'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/edumserrano/github-issue-forms-parser:latest'
   args:
     - parse-issue-form
     - --template-filepath


### PR DESCRIPTION
Build OCI image when there is a change in the main.

The OCI image will be stored in GitHub Packages.
When the action is executed, the action will use the prebuild container, which makes it a lot faster.

## Related issue
Closes #6 

## Development
If you want to test a new feature in a branch, simple point in the `action.yml` to the `Dockerfile` again and you will have a freshly build environment again for each run.

## About the container
The prebuild container has some Secure Software Supply Chain meta files attached to it. The container is signed, has a SLSA provenance file so you can prove it was created in this build pipeline, and a Software Bill of Material in SPDX format, so you can evaluate the content of the container before you want to use it.

