### PR TITLE
Fix broken pipeline due to breaking change inside dotnet v7.0.200

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -107,6 +107,7 @@ jobs:
         $condition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
         Write-Output "condition=$condition" >> $env:GITHUB_OUTPUT
     - name: Generate code coverage report
+      id: code-coverage-report-generator
       if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
       run: |
         $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,12 +22,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     env:
-      SLN_FILEPATH: GitHubIssueFormsParser/GitHubIssueFormsParser.sln
-      TEST_RESULTS_DIR: tests/test-results
-      TEST_COVERAGE_DIR: tests/coverage-results
-      TEST_COVERAGE_MERGE_FILE: tests/coverage-results/coverage.json
-      TEST_COVERAGE_FILE: tests/coverage-results/coverage.opencover.xml
-      TEST_COVERAGE_REPORT_DIR: tests/coverage-results/report
+      SLN_DIR: GitHubIssueFormsParser
+      SLN_FILENAME: GitHubIssueFormsParser.sln
       TEST_RESULTS_ARTIFACT_NAME: test-results
       CODE_COVERAGE_ARTIFACT_NAME: code-coverage-report
     steps:
@@ -40,7 +36,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        global-json-file: GitHubIssueFormsParser/global.json
     - name: Cache/Restore NuGets
       uses: actions/cache@v3
       with:
@@ -52,16 +48,26 @@ jobs:
     - name: Install reportgenerator dotnet tool
       run:  dotnet tool install --global dotnet-reportgenerator-globaltool
     - name: Restore dependencies
-      run: dotnet restore ${{ env.SLN_FILEPATH }}
+      working-directory: ${{ env.SLN_DIR }}
+      run: dotnet restore ${{ env.SLN_FILENAME }}
     - name: Build
-      run: dotnet build ${{ env.SLN_FILEPATH }} -c Release -warnaserror --no-restore --no-incremental
+      working-directory: ${{ env.SLN_DIR }}
+      run: dotnet build ${{ env.SLN_FILENAME }} -c Release -warnaserror --no-restore --no-incremental
     - name: Test and code coverage
       id: dotnet-test
+      working-directory: ${{ env.SLN_DIR }}
       run: |
         $os = $PSVersionTable.OS
-        $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_RESULTS_DIR }}")
+
+        $testResultsDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/test-results")
+        $testCoverageDir = $(Join-Path -Path (Get-Location) -ChildPath "tests/coverage-results/")
+        $testCoverageMergeFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.json")
+        $testCoverageFile = $(Join-Path -Path $testCoverageDir -ChildPath "coverage.opencover.xml")
         Write-Output "test-results-dir=$testResultsDir" >> $env:GITHUB_OUTPUT
-        dotnet test ${{ env.SLN_FILEPATH }} `
+        Write-Output "test-coverage-dir=$testCoverageDir" >> $env:GITHUB_OUTPUT
+        Write-Output "test-coverage-file=$testCoverageFile" >> $env:GITHUB_OUTPUT
+
+        dotnet test ${{ env.SLN_FILENAME }} `
           -c Release `
           --no-build `
           --logger "trx;LogFilePrefix=framework" `
@@ -69,10 +75,14 @@ jobs:
           --logger "liquid.custom;Template=${{github.workspace}}/GitHubIssueFormsParser/tests/liquid-test-logger-template.md;runnerOs=${{ runner.os }};os=$os;LogFilePrefix=framework" `
           --results-directory "$testResultsDir" `
           /p:CollectCoverage=true `
-          /p:CoverletOutput="$(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_COVERAGE_DIR }}/")" `
-          /p:MergeWith="$(Join-Path -Path (Get-Location) -ChildPath "${{ env.TEST_COVERAGE_MERGE_FILE }}")" `
+          /p:CoverletOutput="$testCoverageDir" `
+          /p:MergeWith="$testCoverageMergeFile" `
           /p:CoverletOutputFormat="json%2copencover" `
           -m:1
+
+        Write-Output "test-results-dir is set to $testResultsDir"
+        Write-Output "test-coverage-dir is set to $testCoverageDir"
+        Write-Output "test-coverage-file is set to $testCoverageFile"
 
         $downloadArtifactMessage = "You can inspect the test results by downloading the workflow artifact named: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}."
         if($LASTEXITCODE -eq 0) {
@@ -81,37 +91,48 @@ jobs:
         else {
           Write-Output "::error title=Tests (${{ runner.os }})::Tests failed on ${{ runner.os }}. $downloadArtifactMessage"
         }
-    # Some of the steps below provide feedback on the test run and I want to run them even if some of the previous steps failed. For that
-    # I need:
-    # - the 'always()' condition: without it the step only runs if the job is successful, it's like the 'if' condition on any step always has a hidden '&& success()' clause.
-    # - the '(steps.<step-id>.conclusion == 'success' || steps.<step-id>.conclusion == 'failure')' condition: to run the steps only if the <step-id> step has ran, regardless
-    # if it failed or not. It won't run if the <step-id> step has been skipped or cancelled.
-    - name: Upload test coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: ${{ env.TEST_COVERAGE_FILE }}
-        fail_ci_if_error: true
+    - name: Set run even if tests fail condition
+      id: even-if-tests-fail
+      if: always()
+      run: |
+        # Some of the steps below provide feedback on the test run and I want to run them even if
+        # some of the previous steps failed. For that I need:
+        # - the 'always()' condition: without it the step only runs if the job is successful, it's like the 'if' condition on any step always has a hidden '&& success()' clause.
+        # - the '(steps.<step-id>.conclusion == 'success' || steps.<step-id>.conclusion == 'failure')' condition: to run the steps only if the <step-id> step has ran, regardless
+        # if it failed or not. It won't run if the <step-id> step has been skipped or cancelled.
+        #
+        # As such, the output from this step is meant to be used on the 'if' property of steps as follows:
+        # if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+
+        $condition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
+        Write-Output "condition=$condition" >> $env:GITHUB_OUTPUT
     - name: Generate code coverage report
       if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
       run: |
+        $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")
+        Write-Output "test-coverage-report-dir=$testCoverageReportDir" >> $env:GITHUB_OUTPUT
         reportgenerator `
-          "-reports:${{ env.TEST_COVERAGE_FILE }}" `
-          "-targetdir:${{ env.TEST_COVERAGE_REPORT_DIR }}" `
+          "-reports:${{ steps.dotnet-test.outputs.test-coverage-file }}" `
+          "-targetdir:$testCoverageReportDir" `
           -reportTypes:htmlInline
     - name: Upload code coverage report to artifacts
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
-        path: ${{ env.TEST_COVERAGE_REPORT_DIR }}
-    - name: Log Codecov info
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
-      run: |
-        $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
-        Write-Output "::notice title=Code coverage (${{ runner.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."
+        path: ${{ steps.code-coverage-report-generator.outputs.test-coverage-report-dir }}
     - name: Upload test results to artifacts
-      if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()
+      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
         path: ${{ steps.dotnet-test.outputs.test-results-dir }}
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ${{ steps.dotnet-test.outputs.test-coverage-file }}
+        fail_ci_if_error: true
+    - name: Log Codecov info
+      run: |
+        $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
+        Write-Output "::notice title=Code coverage (${{ runner.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,6 +106,7 @@ jobs:
 
         $condition = '${{ (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') }}'
         Write-Output "condition=$condition" >> $env:GITHUB_OUTPUT
+        Write-Output "condition is set to $condition"
     - name: Generate code coverage report
       id: code-coverage-report-generator
       if: (steps.dotnet-test.conclusion == 'success' || steps.dotnet-test.conclusion == 'failure') && always()

--- a/GitHubIssueFormsParser/global.json
+++ b/GitHubIssueFormsParser/global.json
@@ -1,5 +1,7 @@
 {
-    "sdk": {
-        "version": "7.0.x"
-    }
+  "sdk": {
+      "version": "7.0.103",
+      "rollForward": "disable",
+      "allowPrerelease": false
+  }
 }

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -94,9 +94,13 @@ github-issue-parser parse-issue-form `
 
 ## Projects wide configuration
 
-The [Directory.Build.props](/GitHubIssueFormsParser/Directory.Build.props) enables several settings as well as adds some common NuGet packages for all projects.
+- The [Directory.Build.props](/GitHubIssueFormsParser/Directory.Build.props) enables several settings as well as adds some common NuGet packages for all projects.
 
-There is a set of NuGet packages that are only applied in test projects by using the condition `"'$(IsTestProject)' == 'true'"`. To make this work the `csproj` for the test projects must have the `<IsTestProject>true</IsTestProject>` property defined. Adding this property manually shouldn't be needed because it should be added by the `Microsoft.NET.Test.Sdk` package however there seems to be an issue with this when running tests outside of Visual Studio. See [this GitHub issue](https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198) for more info.
+- There is a set of NuGet packages that are only applied in test projects by using the condition `"'$(IsTestProject)' == 'true'"`. To make this work the `csproj` for the test projects must have the `<IsTestProject>true</IsTestProject>` property defined. Adding this property manually shouldn't be needed because it should be added by the `Microsoft.NET.Test.Sdk` package however there seems to be an issue with this when running tests outside of Visual Studio. See [this GitHub issue](https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198) for more info.
+
+- When running `dotnet` CLI commands make sure you are at the `/GitHubIssueFormsParser` folder so that the `global.json` is respected. If you don't you might get unexpected results when building the solution. As explained in [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json):
+
+> The .NET SDK looks for a global.json file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
 
 ## Deterministic Build configuration
 


### PR DESCRIPTION
The release of `dotnet SDK 7.0.200` broke my build pipeline because a preview version of `MSBuild` started being used.
This also highlighted that I wasn't using the `global.json` file properly. 

This PR:
- pins the SDK version to 7.0.103 until a fix for `MSBuild` is released.
- updated dev README with a note about `global.json`. 
- updates the pipelines to make sure the `global.json` file is respected.
  - the `setup-dotnet` action now uses the `global.json` to determine which version of `dotnet` to install.
  - the `dotnet` CLI commands now run from the directory where `global.json` is. Previously they were run from a directory above and the CLI will only search the current directory and above.

Related issues:
- dotnet/sdk#30624
- actions/setup-dotnet#383