### PR TITLE
Powershell - Passing arguments that contain quote characters

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -62,7 +62,7 @@ jobs:
           "nuget-version": "1.0.13-alpha",
           "auto-generate-release-notes": "Yes",
           "push-nuget": "",
-          "custom-release-notes": "## Custom release notes\n\nTest 123\n\nAnother line:\n- point 1\n- point 2\n- point 3",
+          "custom-release-notes": "## Custom release notes\n\nTest 123\n\"line with double quotes\"\n\nAnother line:\n- point 1\n- point 2\n- point 3",
           "operating-systems": {
             "macos": true,
             "windows": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 # install powershell as per https://docs.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.2
+ARG PWSH_VERSION=7.3.6
 RUN apk add --no-cache \
     ca-certificates \
     less \
@@ -17,7 +18,7 @@ RUN apk add --no-cache \
     icu-libs \
     curl
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
-RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.2.2/powershell-7.2.2-linux-alpine-x64.tar.gz -o /tmp/powershell.tar.gz
+RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-alpine-x64.tar.gz -o /tmp/powershell.tar.gz
 RUN mkdir -p /opt/microsoft/powershell/7
 RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
 RUN chmod +x /opt/microsoft/powershell/7/pwsh

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/CliCommands/ParseIssueFormCommandTests.cs
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/CliCommands/ParseIssueFormCommandTests.cs
@@ -27,7 +27,7 @@ public class ParseIssueFormCommandTests
         issueFormJson.NuGetVersion.ShouldBe("1.0.13-alpha");
         issueFormJson.AutoGenerateReleaseNotes.ShouldBe("Yes");
         issueFormJson.PushNuget.ShouldBeEmpty();
-        issueFormJson.CustomReleaseNotes.ShouldBe($"## Custom release notes{Environment.NewLine}{Environment.NewLine}Test 123{Environment.NewLine}{Environment.NewLine}Another line:{Environment.NewLine}- point 1{Environment.NewLine}- point 2{Environment.NewLine}- point 3");
+        issueFormJson.CustomReleaseNotes.ShouldBe($"## Custom release notes{Environment.NewLine}{Environment.NewLine}Test 123{Environment.NewLine}\"line with double quotes\"{Environment.NewLine}{Environment.NewLine}Another line:{Environment.NewLine}- point 1{Environment.NewLine}- point 2{Environment.NewLine}- point 3");
         issueFormJson.OperatingSystems.ShouldNotBeNull();
         issueFormJson.OperatingSystems.MacOS.ShouldNotBeNull();
         issueFormJson.OperatingSystems.MacOS.ShouldBe(true);

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/IssueBody.md
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/IssueBody.md
@@ -19,6 +19,7 @@ _No response_
 ## Custom release notes
 
 Test 123
+"line with double quotes"
 
 Another line:
 - point 1


### PR DESCRIPTION
## What

This fixes #56 

## Solution

Update `Powershell` used by the GitHub Docker action from version `7.2.2` to `7.3.6`.

## Root cause

The problem was because I use `Powershell` as part of the GitHub Docker action to act as a middle man between the GitHub action and the underlying `dotnet` app which is responsible for parsing the GitHub issue form.

`Powershell` interpreting the quotes in the input argument for the GitHub issue form body which then caused the error. The fix would be around doing some quote escaping but thankfully the new version of `Powershell`, since `7.3`, is already dealing with this out of the box.

See [Passing arguments that contain quote characters](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.3#passing-arguments-that-contain-quote-characters).
