### PR TITLE
Fix logic to find start index for H3 headers in issue forms

### DIFF
--- a/GitHubIssueFormsParser/src/GitHubIssuesParserCli/IssueFormBody/Parsing/IssueFormBodyParser.cs
+++ b/GitHubIssueFormsParser/src/GitHubIssuesParserCli/IssueFormBody/Parsing/IssueFormBodyParser.cs
@@ -13,7 +13,10 @@ internal static class IssueFormBodyParser
         {
             var currentTemplateItem = templateItems[i];
             var nextTemplateItem = templateItems.GetNextTemplateElement(i);
-            var (startIdx, valueLength) = GetLevel3HeaderValueIndexes(currentTemplateItem.Label, nextTemplateItem?.Label, issueFormBodyText);
+            var (startIdx, valueLength) = GetLevel3HeaderValueIndexes(
+                currentTemplateItem.Label,
+                nextTemplateItem?.Label,
+                issueFormBodyText);
             var bodyAsString = (string)issueFormBodyText;
             var value = bodyAsString.Substring(startIdx, valueLength);
             var issueFormItem = IssueFormItemFactory.CreateFormItem(currentTemplateItem.Id, currentTemplateItem.Type, value);
@@ -50,9 +53,26 @@ internal static class IssueFormBodyParser
     private static int GetStartIndex(this IssueFormBodyText issueFormBodyText, string h3HeaderValue)
     {
         var bodyAsString = (string)issueFormBodyText;
-        var startIdx = bodyAsString.IndexOf(h3HeaderValue, StringComparison.Ordinal);
-        return startIdx is -1
-            ? throw IssueFormBodyParserException.H3HeaderNotFound(h3HeaderValue)
-            : startIdx;
+        var h3HeaderValueWindowsLineEnding = h3HeaderValue + NewLines.CR + NewLines.LF;
+        var startIdx = bodyAsString.IndexOf(h3HeaderValueWindowsLineEnding, StringComparison.Ordinal);
+        if (startIdx is not -1)
+        {
+            return startIdx;
+        }
+
+        var h3HeaderValueUnixLineEnding = h3HeaderValue + NewLines.LF;
+        startIdx = bodyAsString.IndexOf(h3HeaderValueUnixLineEnding, StringComparison.Ordinal);
+        if (startIdx is not -1)
+        {
+            return startIdx;
+        }
+
+        throw IssueFormBodyParserException.H3HeaderNotFound(h3HeaderValue);
+    }
+
+    internal static class NewLines
+    {
+        public const string CR = "\r";
+        public const string LF = "\n";
     }
 }

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/CliCommands/ParseIssueFormCommandTests.cs
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/CliCommands/ParseIssueFormCommandTests.cs
@@ -44,7 +44,6 @@ public class ParseIssueFormCommandTests
     /// regardless of the line endings on the issue form body.
     /// </summary>
     [Theory]
-    [InlineData(CR)]
     [InlineData(LF)]
     [InlineData(CR + LF)]
     public async Task ParseIssueFormCommandTest2(string newLine)
@@ -75,5 +74,28 @@ public class ParseIssueFormCommandTests
         issueFormJson.OperatingSystems.Linux.ShouldBe(false);
         issueFormJson.OperatingSystems.Unknown.ShouldNotBeNull();
         issueFormJson.OperatingSystems.Unknown.ShouldBe(false);
+    }
+
+    /// <summary>
+    /// Tests that the <see cref="ParseIssueFormCommand"/> produces the expected JSON output.
+    /// This tests an edge case scenario for matching on the H3 header values. The matching is done
+    /// with an string.IndexOf method and if two H3 headers start with the same value then the matching
+    /// would always return the first occurence.
+    ///
+    /// This has been fixed by changing the matching so that it only matches if the H3 header value
+    /// matches for an entire line, not just the first string occurence.
+    /// </summary>
+    [Fact]
+    public async Task ParseIssueFormCommandTest3()
+    {
+        using var console = new FakeInMemoryConsole();
+        var command = new ParseIssueFormCommand
+        {
+            IssueFormBody = File.ReadAllText("./TestFiles/IssueBody2.md").NormalizeLineEndings(),
+            TemplateFilepath = "./TestFiles/Template2.yml",
+        };
+        await command.ExecuteAsync(console);
+        var output = console.ReadOutputString();
+        output.ShouldNotBeNull();
     }
 }

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/GitHubIssuesParserCli.Tests.csproj
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/GitHubIssuesParserCli.Tests.csproj
@@ -48,6 +48,9 @@
     <None Update="TestFiles\InvalidTemplate2.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestFiles\IssueBody2.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestFiles\IssueBodyWithMangledCheckbox.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -58,6 +61,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestFiles\InvalidTemplate.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFiles\Template2.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestFiles\Template.yml">

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/IssueBody2.md
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/IssueBody2.md
@@ -1,0 +1,7 @@
+### What NuGet package do you want to release?
+
+dotnet-sdk-extensions
+
+### What
+
+dotnet-sdk-extensions-testing

--- a/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/Template2.yml
+++ b/GitHubIssueFormsParser/tests/GitHubIssuesParserCli.Tests/TestFiles/Template2.yml
@@ -1,0 +1,22 @@
+name: Release NuGet package
+description: Release a NuGet package.
+title: Release NuGet package
+body:
+  - type: dropdown
+    id: nuget-id
+    attributes:
+      label: What NuGet package do you want to release?
+      options:
+        - dotnet-sdk-extensions
+        - dotnet-sdk-extensions-testing
+    validations:
+      required: true
+  - type: dropdown
+    id: nuget-id-2
+    attributes:
+      label: What
+      options:
+        - dotnet-sdk-extensions
+        - dotnet-sdk-extensions-testing
+    validations:
+      required: true


### PR DESCRIPTION
The previous logic to find the start index of an H3 header used `string.IndexOf` to find the first occurrence of the header value. The problem with this is that if the GitHub issue template contains labels that start with the same value then this logic will fail to properly identify all the the H3 headers.

Consider this GitHub issue form template:
```yml
name: Release NuGet package
description: Release a NuGet package.
title: Release NuGet package
body:
  - type: dropdown
    id: nuget-id
    attributes:
      label: What NuGet package do you want to release?
      options:
        - dotnet-sdk-extensions
        - dotnet-sdk-extensions-testing
    validations:
      required: true
  - type: dropdown
    id: nuget-id-2
    attributes:
      label: What
      options:
        - dotnet-sdk-extensions
        - dotnet-sdk-extensions-testing
    validations:
      required: true
```

When a GitHub issue is created using the above template then the app would fail to parse the value for the label with id `nuget-id-2` because it would do `<github issue body>.indexOf("### What")` and it would return the index for the label with id `nuget-id` because it also starts with `### What`. 

To fix this we still use `string.IndexOf` but we match on an entire line, meaning it has to have the header value followed by a new line character.