### PR TITLE
Delete global.json

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        global-json-file: GitHubIssueFormsParser/global.json
+        dotnet-version: '9.x'
     - name: Cache/Restore NuGets
       uses: actions/cache@v4
       with:

--- a/GitHubIssueFormsParser/global.json
+++ b/GitHubIssueFormsParser/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-      "version": "9.0.300",
-      "rollForward": "latestMinor",
-      "allowPrerelease": false
-  }
-}

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -101,10 +101,6 @@ github-issue-parser parse-issue-form `
 
 - There is a set of NuGet packages that are only applied in test projects by using the condition `"'$(IsTestProject)' == 'true'"`. To make this work the `csproj` for the test projects must have the `<IsTestProject>true</IsTestProject>` property defined. Adding this property manually shouldn't be needed because it should be added by the `Microsoft.NET.Test.Sdk` package however there seems to be an issue with this when running tests outside of Visual Studio. See [this GitHub issue](https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198) for more info.
 
-- When running `dotnet` CLI commands make sure you are at the `/GitHubIssueFormsParser` folder so that the `global.json` is respected. If you don't you might get unexpected results when building the solution. As explained in [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json):
-
-> The .NET SDK looks for a global.json file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
-
 ## Deterministic Build configuration
 
 Following the guide from [Deterministic Builds](https://github.com/clairernovotny/DeterministicBuilds) the `ContinuousIntegrationBuild` setting on the [Directory.Build.props](/GitHubIssueFormsParser/Directory.Build.props) is set to true, if the build is being executed in GitHub actions.


### PR DESCRIPTION
Removes the `global.json` file and configures the build workflow to directly use the .NET 9 SDK.

This simplifies the build configuration and avoids potential issues related to the working directory when using the `dotnet` CLI.
